### PR TITLE
Fix M73 script to set time at start of print.

### DIFF
--- a/PrusaM73.py
+++ b/PrusaM73.py
@@ -47,13 +47,18 @@ class PrusaM73(Script):
 
                 ## capture the elapsed time, and if the total_time has been
                 ## found, emit the M73 instruction.
-                if total_time is not None and li.startswith(";TIME_ELAPSED:"):
-                    elapsed_time = float(li.split(":", 2)[1])
+                if total_time is not None:
+                    if li.startswith(";LAYER:0"):
+                        time_remaining = round(total_time / 60.0)
+                        new_layer_instructions.append("M73 P0 R{}".format(time_remaining))
+                        
+                    elif li.startswith(";TIME_ELAPSED:"):
+                        elapsed_time = float(li.split(":", 2)[1])
 
-                    progress_pct = round(elapsed_time * 100.0 / total_time)
-                    time_remaining = round((total_time - elapsed_time) / 60.0)
+                        progress_pct = round(elapsed_time * 100.0 / total_time)
+                        time_remaining = round((total_time - elapsed_time) / 60.0)
 
-                    new_layer_instructions.append("M73 P{} R{}".format(progress_pct, time_remaining))
+                        new_layer_instructions.append("M73 P{} R{}".format(progress_pct, time_remaining))
 
             ## replace the layer instructions with our new augmented ones
             layers[layer_ind] = "\n".join(new_layer_instructions)

--- a/PrusaM73.py
+++ b/PrusaM73.py
@@ -30,7 +30,25 @@ class PrusaM73(Script):
 
         ## unset until we find the time in the source data
         total_time = None
-
+        
+        ## get total time and break after finding (quick since it's early)
+        for layer_ind, layer_data in enumerate(layers):
+            ## split layer data into lines
+            layer_instructions = layer_data.split("\n")
+            
+            for li in layer_instructions:
+                ## capture the total print time
+                if total_time is None and li.startswith(";TIME:"):
+                    total_time = float(li.split(":", 2)[1])
+                    break
+                    
+            if total_time is not None:
+                break
+        
+        ## something is wrong with the gcode
+        if total_time is None:
+            return
+        
         ## walk over each layer
         for layer_ind, layer_data in enumerate(layers):
             ## split layer data into lines
@@ -41,24 +59,17 @@ class PrusaM73(Script):
                 ## always capture the original layer info
                 new_layer_instructions.append(li)
 
-                ## capture the total print time
-                if total_time is None and li.startswith(";TIME:"):
-                    total_time = float(li.split(":", 2)[1])
+                ## capture the elapsed time and emit the M73 instruction. also add M73 at start of file like PrusaSlicer
+                if li.startswith(";Generated"):
+                    new_layer_instructions.append("M73 P0 R{} ; set total time".format(round(total_time / 60.0)))
+                    
+                elif li.startswith(";TIME_ELAPSED:"):
+                    elapsed_time = float(li.split(":", 2)[1])
 
-                ## capture the elapsed time, and if the total_time has been
-                ## found, emit the M73 instruction.
-                if total_time is not None:
-                    if li.startswith(";LAYER:0"):
-                        time_remaining = round(total_time / 60.0)
-                        new_layer_instructions.append("M73 P0 R{}".format(time_remaining))
-                        
-                    elif li.startswith(";TIME_ELAPSED:"):
-                        elapsed_time = float(li.split(":", 2)[1])
+                    progress_pct = round(elapsed_time * 100.0 / total_time)
+                    time_remaining = round((total_time - elapsed_time) / 60.0)
 
-                        progress_pct = round(elapsed_time * 100.0 / total_time)
-                        time_remaining = round((total_time - elapsed_time) / 60.0)
-
-                        new_layer_instructions.append("M73 P{} R{}".format(progress_pct, time_remaining))
+                    new_layer_instructions.append("M73 P{} R{}".format(progress_pct, time_remaining))
 
             ## replace the layer instructions with our new augmented ones
             layers[layer_ind] = "\n".join(new_layer_instructions)


### PR DESCRIPTION
This sets an initial M73 at layer 0 to ensure the printer shows the estimated time remaining at the start of the print. Otherwise it will take some time (after first layer) before the first M73 is inserted.

This mirrors the behavior of PrusaSlicer.